### PR TITLE
Use the ProxyWriter in ServeHTTP to get code and length

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -366,7 +366,7 @@ func isWebsocketRequest(req *http.Request) bool {
 
 // serveHTTP forwards HTTP traffic using the configured transport
 func (f *httpStreamingForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx *handlerContext) {
-	pw := utils.ProxyWriter{
+	pw := &utils.ProxyWriter{
 		W: w,
 	}
 	start := time.Now().UTC()
@@ -387,7 +387,7 @@ func (f *httpStreamingForwarder) serveHTTP(w http.ResponseWriter, req *http.Requ
 
 	revproxy := httputil.NewSingleHostReverseProxy(urlcpy)
 	revproxy.FlushInterval = f.flushInterval //Flush something every 100 milliseconds
-	revproxy.ServeHTTP(w, req)
+	revproxy.ServeHTTP(pw, req)
 
 	if req.TLS != nil {
 		log.Infof("Round trip: %v, code: %v, Length: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",


### PR DESCRIPTION
I noticed that the pw isn't actually used in ServeHTTP, and we're getting "code: 0, length: 0" in the log output. 
This change passes pw to ServeHTTP, and it also instantiates it as a pointer to satisfy the http.ResponseWriter interface.

There were no unit tests to update for this change. I'll try to write a test for the streaming forwarder case sometime soon.